### PR TITLE
add arm64 docker support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: Set up Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1.3.0
@@ -66,7 +72,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
This adds support for building arm64 (multi-arch) Docker images.

We need this over on our [KubeSail template](https://kubesail.com/template/erulabs/photostructure) in order to run on PiBoxes :)