### PR TITLE
defaults.env fix typo `cpuLoadPercent` to `cpuBusyPercent`

### DIFF
--- a/defaults.env
+++ b/defaults.env
@@ -1000,10 +1000,10 @@
 # How many imports can PhotoStructure schedule concurrently? This will be
 # clamped between 1 and 32.
 #
-# If not set, a sensible value will be computed based on "cpuLoadPercent".
+# If not set, a sensible value will be computed based on "cpuBusyPercent".
 #
 # If set explicitly, this and "sharpThreadsPerProcess" will override
-# "cpuLoadPercent" and "maxConcurrentImportsWhenRemote" settings.
+# "cpuBusyPercent" and "maxConcurrentImportsWhenRemote" settings.
 #
 # Aliases: "PS_MAX_SYNC_FILE_JOBS"
 #
@@ -1016,7 +1016,7 @@
 #
 # How many concurrent files can be imported if the library is on a remote
 # volume? This defaults to 2 to try to avoid overwhelming HDD I/O on the
-# remote NAS. If this is larger than (cpus.length * cpuLoadPercent) or max
+# remote NAS. If this is larger than (cpus.length * cpuBusyPercent) or max
 # child processes given available memory, this value will be ignored.
 #
 # Aliases: "PS_MAX_SYNC_FILE_JOBS_WHEN_REMOTE"


### PR DESCRIPTION
Fix typo `cpuLoadPercent` to `cpuBusyPercent`